### PR TITLE
Log error message

### DIFF
--- a/pkg.go
+++ b/pkg.go
@@ -3,6 +3,7 @@ package depth
 import (
 	"bytes"
 	"go/build"
+	"log"
 	"path"
 	"sort"
 	"strings"
@@ -43,7 +44,7 @@ func (p *Pkg) Resolve(i Importer) {
 
 	pkg, err := i.Import(name, p.SrcDir, importMode)
 	if err != nil {
-		// TODO: Check the error type?
+		log.Println(err)
 		p.Resolved = false
 		return
 	}


### PR DESCRIPTION
Error logging helps to track down issues.
For example, I was investigating why swaggo failed in my project and found the `package name is not in GOROOT` error after I modified depth/pkg.go. It wasn't an obvious thing in my project.

This PR adds error logging in the pkg.go file when it fails to import.